### PR TITLE
Add game logic tests and CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,25 @@
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+    - name: Run tests
+      run: |
+        pytest

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Workspace
+
+This repository contains a small game logic example used for demonstrating
+unit testing with `pytest`.
+
+## Running tests
+
+Install `pytest` and run:
+
+```
+pytest
+```

--- a/game.py
+++ b/game.py
@@ -1,0 +1,28 @@
+class Entity:
+    def __init__(self, x, y, width=1, height=1):
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+
+    def move(self, dx, dy, bounds=None):
+        """Move the entity by dx and dy. If bounds is provided as
+        (max_x, max_y), the entity's position is clamped so that it
+        remains within [0, max_x - width] and [0, max_y - height]."""
+        new_x = self.x + dx
+        new_y = self.y + dy
+        if bounds:
+            max_x, max_y = bounds
+            new_x = max(0, min(new_x, max_x - self.width))
+            new_y = max(0, min(new_y, max_y - self.height))
+        self.x = new_x
+        self.y = new_y
+
+    def collides_with(self, other):
+        """Return True if this entity collides with another."""
+        return not (
+            self.x + self.width <= other.x or
+            self.x >= other.x + other.width or
+            self.y + self.height <= other.y or
+            self.y >= other.y + other.height
+        )

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,30 @@
+import pytest
+
+from game import Entity
+
+
+def test_move_within_bounds():
+    e = Entity(0, 0)
+    e.move(3, 4, bounds=(10, 10))
+    assert (e.x, e.y) == (3, 4)
+
+
+def test_move_clamped_to_bounds():
+    e = Entity(8, 8, width=2, height=2)
+    e.move(5, 5, bounds=(10, 10))
+    # should be clamped so entity stays in bounds
+    assert (e.x, e.y) == (8, 8)
+
+
+def test_collision_true():
+    a = Entity(0, 0, width=2, height=2)
+    b = Entity(1, 1, width=2, height=2)
+    assert a.collides_with(b)
+    assert b.collides_with(a)
+
+
+def test_collision_false():
+    a = Entity(0, 0, width=2, height=2)
+    b = Entity(3, 3, width=2, height=2)
+    assert not a.collides_with(b)
+    assert not b.collides_with(a)


### PR DESCRIPTION
## Summary
- add example game logic module with movement and collision
- create pytest unit tests for movement and collision
- document how to run tests
- set up GitHub Actions workflow to run pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844540c05b88333aabfc47b5ad9aef9